### PR TITLE
Catch DirectoryNotFoundException

### DIFF
--- a/SingleAppInstance/SingleAppInstance.cs
+++ b/SingleAppInstance/SingleAppInstance.cs
@@ -88,6 +88,9 @@ public static class SingleAppInstance
 				return true;
 			}
 		}
+		catch (DirectoryNotFoundException)
+		{
+		}
 		catch (FileNotFoundException)
 		{
 		}


### PR DESCRIPTION
It is possible the entire target directory where the pid file lives may not exist. In that instance a DirectoryNotFoundException will be thrown instead of FileNotFoundException.